### PR TITLE
Fix unexpected end of input error while installing in Windows

### DIFF
--- a/R/features-exp.R
+++ b/R/features-exp.R
@@ -82,7 +82,7 @@ extract_features_exp <- function(x) {
       athkarapp = sum_("athkarApp" %in% .data$source) / .data$n,
       mobilewebm2 = sum_("Mobile Web (M2)" %in% .data$source) / .data$n,
       twitterfeed = sum_("twitterfeed" %in% .data$source) / .data$n,
-      tweetbotforiοs = sum_("Tweetbot for iΟS" %in% .data$source) / .data$n,
+      tweetbotforios = sum_("Tweetbot for iOS" %in% .data$source) / .data$n,
       tweetcasterforandroid = sum_(
         "TweetCaster for Android" %in% .data$source) / .data$n,
       twitcomcomunidades = sum_(


### PR DESCRIPTION
Hi there,

I was having issues installing the package from GitHub. I kept getting an error about an unexpected end of input on line 85 of feature-exp.R that almost certainly comes down to an issue with Windows (I successfully installed on MacOS yesterday)

All I've done is re-write line 85 and all seems to be fixed. I guess that there has been some weird whitespace encoding on Mac/linux when the code was written. Although even GitHub's code viewer shows something weird is happening:
https://github.com/mkearney/tweetbotornot/blob/4631a82c7cbce425b6bfff5989213c9b865acaf2/R/features-exp.R#L85

I've tested the "changes" on both Windows and MacOS 