### PR TITLE
Fix when fast = TRUE only able to check 180 users per 15 min, not 90000 users

### DIFF
--- a/R/tweetbotornot.R
+++ b/R/tweetbotornot.R
@@ -88,16 +88,10 @@ botornot.factor <- function(x, fast = FALSE) {
 botornot.character <- function(x, fast = FALSE) {
   ## remove NA and duplicates
   x <- x[!is.na(x) & !duplicated(x)]
-  if (fast) 
-  {
+  
     ## get user level info
-    x <- rtweet::lookup_users(x)
-  }
-  else
-    {
-    ## get most recent 100 tweets
-    x <- rtweet::get_timelines(x, n = 100)
-    }
+  x <- rtweet::lookup_users(x)
+  
   ## pass to next method
   botornot(x, fast = fast)
 }


### PR DESCRIPTION
This proposed change will fix the issues mentioned in issue #23 and #24, which is even with the fast argument on, this API could only check 180 users per 15 minutes, instead of 90000 users per 15 minutes. With this fix, this API is able to check 90000 users per 15 minutes.

in line 89 to 96 of
tweetbotornot/R/tweetbotornot.R

I changed

botornot.character <- function(x, fast = FALSE) {
x <- x[!is.na(x) & !duplicated(x)]
x <- rtweet::get_timelines(x, n = 100)
botornot(x, fast = fast)
}

to

botornot.character <- function(x, fast = FALSE) {
x <- x[!is.na(x) & !duplicated(x)]
if (fast)
{
x <- rtweet::lookup_users(x)
}
else
{
x <- rtweet::get_timelines(x, n = 100)
}
botornot(x, fast = fast)
}

so that it only takes user-level data if fast argument is on, without looking at user's timeline which only has a rate limit of 180 users / 15 minutes.